### PR TITLE
STAR-5338: redis-py-cluster version pin

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -54,4 +54,4 @@ uwsgi>2.0.0,<2.1.0
 rb>=1.7.0,<2.0.0
 qrcode>=5.2.2,<6.0.0
 python-u2flib-server>=4.0.1,<4.1.0
-redis-py-cluster>=1.3.4,<1.4.0
+redis-py-cluster==1.3.4

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ from sentry.utils.distutils import (
 )
 
 # The version of sentry
-VERSION = '8.22.1-sf.4'
+VERSION = '8.22.1-sf.5'
 
 # Hack to prevent stupid "TypeError: 'NoneType' object is not callable" error
 # in multiprocessing/util.py _exit_function when running `python


### PR DESCRIPTION
Version 1.3.5 requires at least redis 2.10.6, which may break Sentry
according to Sentry PR #5905.